### PR TITLE
Added setDeliverEmail method to Signer class

### DIFF
--- a/lib/Signer.js
+++ b/lib/Signer.js
@@ -93,6 +93,13 @@ function Signer(newSigner = {}) {
      * @type {Date}
      */
     embeddedSigningUrl: undefined,
+      
+     /**
+     * Forces document to be emailed in the case embedded signing is enabled for this template
+     * Usually starts with 1 for the first Signer.
+     * @type {Boolean}
+     */
+    setDeliverEmail: undefined,
   };
 
   Object.assign(signer, newSigner);
@@ -208,6 +215,10 @@ function Signer(newSigner = {}) {
   this.getEmbeddedSigningUrl = function () {
     return signer.embeddedSigningUrl;
   };
+    
+   this.setDeliverEmail = function(newDeliverEmail) {
+        signer.deliver_email = newDeliverEmail;
+    };
 
 }
 


### PR DESCRIPTION
Right now if the template has embeddable signing enabled for it the document is not sent to the signer's email address. I've added a method to allow the signer attribute _'deliver_email'_ to be set to 1 and thus reenable the email to be sent.