### PR TITLE
fix(delete-cancel-document): Fix error on cancel/delete a document

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -298,7 +298,8 @@ function Client(accessKey, businessId){
         if (!document.getDocumentHash()) {
           throw new Error('Deleting the Document requires the Document Hash');
         }
-        if (!document.getIsDraft() && !document.getIsCanceled()) {
+        // Do not check on cancel
+        if (!type && !document.getIsDraft() && !document.getIsCanceled()) {
           throw new Error('Only Drafts and cancelled Documents can be deleted');
         }
         if (document.getIsDeleted()) {
@@ -311,7 +312,7 @@ function Client(accessKey, businessId){
         if(type) {
           parameters[type] = 1;
         }
-        var request = new ApiRequest("DELETE", accessKey, config.DOCUMENT_URL, undefined, $parameters);
+        var request = new ApiRequest("DELETE", accessKey, config.DOCUMENT_URL, undefined, parameters);
         return request.startRequest().then(resolve).catch(reject);
       }).catch(function(err) {
         console.error(err)

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -168,15 +168,11 @@ function Client(accessKey, businessId){
   this.uploadFile = function (file) {
     return new Promise(function(resolve, reject) {
         getBusinessId().then(function (businessId) {
-            if(!file.getFilePath())
-              throw new Error('File needs a local file Path to be uploaded');
-            if(!fs.existsSync(file.getFilePath()))
-              throw new Error('Local File could not be found');
             var parameters = {
               "business_id" : selectedBusiness ? selectedBusiness.getBusinessId(): businessId,
             };
 
-            var request = new ApiRequest("POST", accessKey, config.FILE_URL, 'File', parameters, file.getFilePath());
+            var request = new ApiRequest("POST", accessKey, config.FILE_URL, 'File', parameters, file.getFileBase64());
             return request.startMultipartUpload().then(resolve).catch(reject);
         }).catch(function(err) {
           console.error(err)

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -58,7 +58,7 @@ ApiRequest.prototype.startMultipartUpload = function () {
       uri: config.API_URL + self.endPoint + "?" + qs.stringify(createQuery(self)),
       headers: self.headers,
       formData: {
-        upload: fs.createReadStream(path.resolve(self.payload))
+        upload: Buffer.from(self.payload, 'base64')
       },
     },
     function (error, response, body) {


### PR DESCRIPTION
Here is a fix for delete/cancel document.

1. Fix an error with `$parameters` which don't exist
2. Fix cancel document error `Only Drafts and cancelled Documents can be deleted`. This error has to be throw only when deleting a document. Not on cancel