### PR TITLE
fix: consistent naming getreadOnly -> getReadOnly

### DIFF
--- a/lib/Readable.js
+++ b/lib/Readable.js
@@ -17,7 +17,7 @@ function Readable(newReadable = {}) {
     this.readAble = readOnly;
   }
 
-  this.getreadOnly = function () {
+  this.getReadOnly = function () {
     return readAble.readOnly;
   };
 


### PR DESCRIPTION
BREAKING CHANGE: renamed API