### PR TITLE
fix: evade Unhandled Promise Rejections

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -85,23 +85,22 @@ function Client(accessKey, businessId){
   };
 
   function getDocuments(type, dataType) {
-    return new Promise(function(resolve, reject) {
-        getBusinessId().then(function (businessId) {
-            if(!type) type = "all"
-            var parameters = {
-              "business_id" : businessId,
-              "type" : type
-            };
-            var request = new ApiRequest("GET", accessKey, config.DOCUMENT_URL, dataType ? dataType : 'Document', parameters);
-            request.startRequest().then(resolve).catch(reject);
-        }).catch(function(err) {
-          console.error(err)
-        });
-    });
-
+    return getBusinessId()
+      .then(function (businessId) {
+        if(!type) type = "all"
+        var parameters = {
+          "business_id" : businessId,
+          "type" : type
+        };
+        var request = new ApiRequest("GET", accessKey, config.DOCUMENT_URL, dataType ? dataType : 'Document', parameters);
+        return request.startRequest();
+      });
 
   }
 
+  /**
+   * UnhandledPromiseRejection unsafe. Handle with care! TODO: fix.
+   */
   this.createDocument = function (document) {
     var self = this;
     return new Promise(function(resolve, reject) {
@@ -166,22 +165,19 @@ function Client(accessKey, businessId){
   };
 
   this.uploadFile = function (file) {
-    return new Promise(function(resolve, reject) {
-        getBusinessId().then(function (businessId) {
-            if(!file.getFilePath())
-              throw new Error('File needs a local file Path to be uploaded');
-            if(!fs.existsSync(file.getFilePath()))
-              throw new Error('Local File could not be found');
-            var parameters = {
-              "business_id" : selectedBusiness ? selectedBusiness.getBusinessId(): businessId,
-            };
+    return getBusinessId()
+      .then(function (businessId) {
+        if(!file.getFilePath())
+          throw new Error('File needs a local file Path to be uploaded');
+        if(!fs.existsSync(file.getFilePath()))
+          throw new Error('Local File could not be found');
+        var parameters = {
+          "business_id" : selectedBusiness ? selectedBusiness.getBusinessId(): businessId,
+        };
 
-            var request = new ApiRequest("POST", accessKey, config.FILE_URL, 'File', parameters, file.getFilePath());
-            return request.startMultipartUpload().then(resolve).catch(reject);
-        }).catch(function(err) {
-          console.error(err)
-        });
-    });
+        var request = new ApiRequest("POST", accessKey, config.FILE_URL, 'File', parameters, file.getFilePath());
+        return request.startMultipartUpload();
+      });
   }
 
   /**
@@ -219,8 +215,8 @@ function Client(accessKey, businessId){
    * @return {Promise}          [description]
    */
   this.sendReminderForDocument = function (document, signer) {
-    return new Promise(function(resolve, reject) {
-      getBusinessId().then(function (businessId) {
+    return getBusinessId()
+      .then(function (businessId) {
         if(!document.getDocumentHash() || !document.getSigners() )
           throw new Error('Sending Reminders requires the Document Hash and an approriate Signer');
         var parameters = {
@@ -231,11 +227,8 @@ function Client(accessKey, businessId){
           signer_id: signer.getId()
         };
         var request = new ApiRequest("POST", accessKey, config.REMINDER_URL, undefined, parameters, payload);
-        return request.startRequest().then(resolve).catch(reject);
-      }).catch(function(err) {
-        console.error(err)
+        return request.startRequest();
       });
-    });
   };
 
   /**
@@ -245,29 +238,26 @@ function Client(accessKey, businessId){
    * @return {Promise}              [description]
    */
   this.getDocumentByHash = function (documentHash) {
-    return new Promise(function(resolve, reject) {
-      getBusinessId().then(function (businessId) {
+    return getBusinessId()
+      .then(function (businessId) {
         var parameters = {
           business_id : businessId,
           document_hash : documentHash
         };
         var request = new ApiRequest("GET", accessKey, config.DOCUMENT_URL, 'Document', parameters);
-        return request.startRequest().then(resolve).catch(reject);
-      }).catch(function(err) {
-        console.error(err)
+        return request.startRequest();
       });
-    });
   };
 
   /**
    *
    *
-   * @param  {[type]} template [description]
-   * @return {[type]}          [description]
+   * @param  {Template} template
+   * @return {Document}
    */
   this.createDocumentFromTemplate = function (template) {
-    return new Promise(function(resolve, reject) {
-      getBusinessId().then(function (businessId) {
+    return getBusinessId()
+      .then(function (businessId) {
         template = template.toObject();
 
         if(!template.getTemplateId()){
@@ -281,11 +271,8 @@ function Client(accessKey, businessId){
         };
 
         var request = new ApiRequest("POST", accessKey, config.DOCUMENT_URL, 'Document', parameters, template);
-        return request.startRequest().then(resolve).catch(reject);
-      }).catch(function(err) {
-        console.error(err)
+        return request.startRequest();
       });
-    });
 
   };
 
@@ -297,8 +284,8 @@ function Client(accessKey, businessId){
    * @return {Promise}          [description]
    */
   this.deleteDocument = function (document, type) {
-    return new Promise(function(resolve, reject) {
-      getBusinessId().then(function (businessId) {
+    return getBusinessId()
+      .then(function (businessId) {
         if (!document.getDocumentHash()) {
           throw new Error('Deleting the Document requires the Document Hash');
         }
@@ -316,11 +303,9 @@ function Client(accessKey, businessId){
           parameters[type] = 1;
         }
         var request = new ApiRequest("DELETE", accessKey, config.DOCUMENT_URL, undefined, $parameters);
-        return request.startRequest().then(resolve).catch(reject);
-      }).catch(function(err) {
-        console.error(err)
+        return request.startRequest();
       });
-    });
+
   };
 
   this.cancelDocument = function (document) {
@@ -354,8 +339,8 @@ function Client(accessKey, businessId){
   };
 
   function downloadDocumentToPath(document, path, auditTrail = 0, type = config.DOCUMENT_FINAL_URL) {
-    return new Promise(function(resolve, reject) {
-      getBusinessId().then(function (businessId) {
+    return getBusinessId()
+      .then(function (businessId) {
         if (!path || !document) {
           throw new Error('To Download the Document you need to set a path and the document');
         }
@@ -370,11 +355,9 @@ function Client(accessKey, businessId){
         };
 
         var request = new ApiRequest("GET", accessKey, type, "Document", parameters, payload);
-        return request.startDownload().then(resolve).catch(reject);
-      }).catch(function(err) {
-        console.error(err)
+        return request.startDownload();
       });
-    });
+
   };
 
   /**
@@ -414,32 +397,33 @@ function Client(accessKey, businessId){
       accessKey = 'Bearer ' + oauthToken;
   }
 
-    function getBusinessId() {
-        return new Promise(function(resolve, reject) {
-            var request = new ApiRequest("GET", accessKey, config.BUSINESS_URL, 'Business');
-            if(businessId) {
+  function getBusinessId() {
+    return new Promise(function(resolve, reject) {
+      try {
+        if(businessId) {
+          resolve(businessId);
+        } else if(selectedBusiness) {
+          resolve(selectedBusiness.getBusinessId());
+        } else {
+          var request = new ApiRequest("GET", accessKey, config.BUSINESS_URL, 'Business');
+          return request.startRequest()
+            .then(function(businesses) {
+              if(businessId) {
                 resolve(businessId);
-            } else if(selectedBusiness) {
+              } else {
+                selectedBusiness = businesses.filter(function functionName(business) {
+                  return business.isPrimary();
+                })[0];
                 resolve(selectedBusiness.getBusinessId());
-            } else {
-                request.startRequest().then(function(response) {
-                    businesses = response;
-                    if (businessId) {
-                        resolve(businessId);
-                    } else {
-                        selectedBusiness = businesses.filter(function functionName(business) {
-                            return business.isPrimary();
-                        })[0];
-                        resolve(selectedBusiness.getBusinessId());
-                    }
-                }).catch(function(err) {
-                    reject(err);
-                });
-            }
-        }).catch(function(err) {
-          console.error(err)
-        });
-    }
+              }
+            })
+            .catch(reject);
+        }
+      } catch(err) {
+        reject(err)
+      }
+    });
+  }
 }
 
 module.exports = Client;


### PR DESCRIPTION
Unhandled promise rejections denies consumer to handle or even notice the thrown error.

Furthermore, in future versions of Node.js it will crash consumer's process:

> NodeJS warning:
> [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

BREAKING CHANGES:
1. If someone has already hacked around UnhandledPromiseRejection, they will need to handle them properly now (e.g. `client.doStuff(badInput).catch((err) => console.error(err))`).
2. `console.error(err)` were inconsistent - they logged some errors, but not all of them. After this change they would have logged either all errors or none - I chose none. Rationale: consumer can easily add `.catch((err) => console.error(err))` to have them logged whenever needed, but other way around it's complicated to get rid of them.