### PR TITLE
Fix creation of documents containing base64 file content

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -115,7 +115,7 @@ function Client(accessKey, businessId){
             };
 
             async.forEachOf(document.getFiles(), function (file, index, callback) {
-              if(file.getFilePath() || file.getFileBase64()) {
+              if(file.getFilePath()) {
                 self.uploadFile(file)
                 .then(function (response) {
 
@@ -140,6 +140,7 @@ function Client(accessKey, businessId){
 
               _.forEach(document.files, function(file, index) {
                 var sendFile = _.mapKeys(file, function(value, key) {
+                  if(key == 'fileBase64') return 'file_base64';
                   return _.snakeCase(key);
                 });
                 document.files[index] = sendFile;

--- a/lib/Document.js
+++ b/lib/Document.js
@@ -264,7 +264,7 @@ function Document(newDocument = {}) {
    */
   this.appendFile = function (file) {
     file = file.toObject();
-    if( !file.getFilePath() && !file.getFileId() && !file.getFileUrl() && file.getFileBase64() )
+    if( !file.getFilePath() && !file.getFileId() && !file.getFileUrl() && !file.getFileBase64() )
       throw new Error('File object needs a real File to be associated');
 
     if( !file.getName() )


### PR DESCRIPTION
Fix support for inlined base64 encoded documents to be uploaded during the document creation request. The fix included:
- skipping the upload request in case an inlined document is present
- fixing the presence verification to allow inlined documents (adding the negation sign)
- fixing the blanket application of the snake case converter, which erroneously turns `fileBase64` into `file_base_64` while our API requires the key to be name `file_base64`