### PR TITLE
Fix appendRecipient() bug

### DIFF
--- a/lib/DocumentTemplate.js
+++ b/lib/DocumentTemplate.js
@@ -139,6 +139,7 @@ function Template(templateId) {
   };
 
   this.appendRecipient = function (recipient) {
+    recipient = recipient.toObject();
     if(!recipient.getRole() || !recipient.getName() || !recipient.getEmail()){
       throw new Error('Recipient needs at least a Name, a Role and an E-Mail address');
     }


### PR DESCRIPTION
Added recipient = recipient.toObject(); to fix bug where recipients weren't being pushed to the recipients array.