### PR TITLE
fix: property name is_cancelled has UK spelling

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -70,11 +70,11 @@ function Document(newDocument = {}) {
     isTrashed: undefined,
 
     /**
-     * Check if the document has been canceled.
-     * @var {Boolean} isCanceled
+     * Check if the document has been cancelled.
+     * @var {Boolean} isCancelled
      * @type {Boolean}
      */
-    isCanceled: undefined,
+    isCancelled: undefined,
 
     /**
      *
@@ -390,8 +390,9 @@ function Document(newDocument = {}) {
     return document.isCompleted;
   };
 
-  this.getIsCanceled = function () {
-    return document.isCanceled;
+  // UK Spelling. Check ApiDoc: https://eversign.com/api/documentation/methods#get-document-template
+  this.getIsCancelled = function () {
+    return document.isCancelled;
   };
 
   this.getIsDeleted = function () {


### PR DESCRIPTION
Check https://eversign.com/api/documentation/methods#get-document-template
This fixes isCanceled() to return undefined when retrieving a Document in declined state.

Fixes #52 