### PR TITLE
Solve the inline require bug when using bundlers

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -7,8 +7,19 @@ var _ = require('lodash');
 var path = require('path');
 var qs = require('querystring');
 var Promise = require('bluebird');
+var Document = require('./Document.js');
+var Business = require('./Business.js');
+var File = require('./File.js');
+var DocumentTemplate = require('./DocumentTemplate.js');
 
 module.exports = ApiRequest;
+
+var TypeMap = {
+  Document,
+  DocumentTemplate,
+  File,
+  Business,
+}
 
 /**
  *
@@ -134,7 +145,7 @@ ApiRequest.prototype.startRequest = function(){
         reject(err);
       } else {
         if(self.responseType){
-          var Type = require('./' + self.responseType);
+          var Type = TypeMap[self.responseType];
           if(res.length){
             //is an array
             var result = res.map(function (obj) {


### PR DESCRIPTION
When using bundlers like webpack, esbuild, etc, the inline `require` call here fails to load the module because it has all been bundled into one file. This change is a proposal to require the necessary modules at the top of the file and use a mapping to decide which `Type` to use.